### PR TITLE
go vet found struct tag issue

### DIFF
--- a/cluster_state.go
+++ b/cluster_state.go
@@ -7,7 +7,7 @@ type ClusterState struct {
 
 type Collection struct {
 	Shards            map[string]Shard `json:"shards"`
-	ReplicationFactor string           `json:replicationFactor`
+	ReplicationFactor string           `json:"replicationFactor"`
 }
 
 type Shard struct {


### PR DESCRIPTION
Go Vet noticed this issue.
```
go vet ./...
cluster_state.go:10: struct field tag `json:replicationFactor` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
```